### PR TITLE
Allow Nancy to discover views

### DIFF
--- a/Bootstrapper.cs
+++ b/Bootstrapper.cs
@@ -1,0 +1,42 @@
+namespace FringeNancy
+{
+    using Nancy;
+    using Nancy.TinyIoc;
+    using Microsoft.Framework.Runtime;
+
+    public class Bootstrapper : DefaultNancyBootstrapper
+    {
+        private IApplicationEnvironment appEnv;
+        
+        protected override IRootPathProvider RootPathProvider { get { return new RootPathProvider(appEnv); }}
+        
+        public Bootstrapper(IApplicationEnvironment appEnv)
+        {
+            this.appEnv = appEnv;
+        }
+        
+        protected override void ApplicationStartup(TinyIoCContainer container, Nancy.Bootstrapper.IPipelines pipelines)
+        {
+            this.Conventions.ViewLocationConventions.Add((viewName, model, context) =>
+            {
+                return string.Concat("wwwroot/", viewName);
+            });
+        }
+    }
+    
+    public class RootPathProvider : IRootPathProvider
+    {
+        
+        public IApplicationEnvironment appEnv;
+        
+        public RootPathProvider(IApplicationEnvironment appEnv)
+        {
+            this.appEnv = appEnv;
+        }
+        
+        public string GetRootPath() 
+        {
+            return appEnv.ApplicationBasePath;
+        }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -2,15 +2,16 @@ namespace FringeNancy
 {
     using Microsoft.AspNet.Builder;
     using Nancy.Owin;
-    using System;
  
     public class Startup
     {
-        public void Configure(IApplicationBuilder app)
+        public void Configure(IApplicationBuilder app, Microsoft.Framework.Runtime.IApplicationEnvironment appEnv)
         {
         	app.UseStaticFiles();
-        	Console.WriteLine("test");
-            app.UseOwin(x => x.UseNancy());
+            
+            var opts = new NancyOptions();
+            opts.Bootstrapper = new Bootstrapper(appEnv);
+            app.UseOwin(x => x.UseNancy(opts));
         }
     }
 }


### PR DESCRIPTION
This required two main tweaks to get it running with nancy,

First : The custom view locator to find it in the wwwroot.
Second : The implimentation of a custom IRootPathProvider to work with the new aspnet IApplicationEnvironment stuff.
